### PR TITLE
Addendum v9: reader ambience, about tile, BPM sync, live status

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -56,13 +56,15 @@
   <div class="utility-strip glass-surface">
     <div class="status">
       <span class="dot" aria-hidden="true"></span>
-      {% if github.configured and github.available %}
-        <span class="label">currently building</span>
-        <a href="{{ github.repoUrl }}" target="_blank" rel="noopener">{{ github.repoName }}</a>
-        {% if github.description %}<span class="label">— {{ github.description }}</span>{% endif %}
-      {% else %}
-        <span class="label">{{ site.manualStatus }}</span>
-      {% endif %}
+      <span id="statusText" data-username="{{ site.githubUsername }}">
+        {% if github.configured and github.available %}
+          <span class="label">currently building</span>
+          <a href="{{ github.repoUrl }}" target="_blank" rel="noopener">{{ github.repoName }}</a>
+          {% if github.description %}<span class="label">— {{ github.description }}</span>{% endif %}
+        {% else %}
+          <span class="label">{{ site.manualStatus }}</span>
+        {% endif %}
+      </span>
     </div>
     <div class="tools">
       <button class="theme-switch" id="themeSwitch" aria-label="Toggle light and dark theme" type="button">

--- a/src/about.njk
+++ b/src/about.njk
@@ -5,7 +5,7 @@ permalink: /about/
 ---
 
 <main id="main">
-<section style="max-width: 65ch;">
+<section style="max-width: 640px; margin-inline: auto;">
   <p class="section-label">— ABOUT</p>
 
   <div class="glass-surface" style="font-size: 16px; line-height: 1.9; color: var(--body); padding: 24px 26px;">

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -106,6 +106,13 @@
   --glass-edge:   rgba(241,219,203,0.14);
 }
 
+/* v9: the about tile itself reads darker — ~20% light through — while the
+   root about palette (ink text, clay accents) stays as tuned above. */
+[data-page="about"] .glass-surface {
+  --glass-tint: rgba(12,7,4,0.80);
+  --glass-solid: rgba(12,7,4,0.92);
+}
+
 html { -webkit-text-size-adjust: 100%; transition: background-color 0.3s; }
 body {
   background: var(--sky-bottom); /* fallback if canvas/JS is unavailable */
@@ -515,7 +522,21 @@ nav a:hover, nav a:focus { color: var(--accent); outline: none; }
 /* ───────────────────────────────────────
    READER MODE — a calm, solid reading surface (blog + post pages only)
    ─────────────────────────────────────── */
-html.reading-mode .scene { display: none; }
+/* v9: the scene stays visible but drifts into a soft, blurred amber wash —
+   light through thick frosted glass — instead of disappearing outright. */
+html.reading-mode .scene-sky {
+  filter: blur(48px) saturate(1.1);
+  opacity: 0.55;
+  transition: filter 0.8s ease, opacity 0.8s ease;
+}
+html.reading-mode .scene::after {
+  content: "";
+  position: absolute; inset: 0; z-index: 2;
+  background: radial-gradient(60% 50% at 50% 45%, rgba(232,160,70,0.22), transparent 80%),
+              rgba(232,160,70,0.06);
+  mix-blend-mode: soft-light;
+  pointer-events: none;
+}
 html.reading-mode body { background: var(--bg); }
 html.reading-mode .glass-surface {
   background: var(--bg-elevated);

--- a/src/js/site.js
+++ b/src/js/site.js
@@ -255,3 +255,60 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal()
 
   open();
 })();
+
+// ── live "currently building" status ──
+// github.json (baked in at build time) is the initial paint and the no-JS
+// fallback. This just asks GitHub directly, client-side, so the status
+// reflects the very latest push within seconds of loading the page, with
+// no rebuild. Any failure — offline, rate-limited, no push found — leaves
+// the server-rendered value alone.
+(function () {
+  const textEl = document.getElementById('statusText');
+  if (!textEl) return;
+  const username = textEl.dataset.username;
+  if (!username || username === 'yourusername') return;
+
+  const CACHE_KEY = 'github-status-cache';
+  const CACHE_MS = 3 * 60 * 1000;
+
+  function render(repo, url) {
+    textEl.textContent = '';
+    const label = document.createElement('span');
+    label.className = 'label';
+    label.textContent = 'currently building';
+    const link = document.createElement('a');
+    link.href = url;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.textContent = repo;
+    textEl.appendChild(label);
+    textEl.appendChild(document.createTextNode(' '));
+    textEl.appendChild(link);
+  }
+
+  function fromCache() {
+    try {
+      const s = JSON.parse(sessionStorage.getItem(CACHE_KEY) || 'null');
+      if (s && typeof s.fetchedAt === 'number' && Date.now() - s.fetchedAt < CACHE_MS) return s;
+    } catch (e) {}
+    return null;
+  }
+  function toCache(repo, url) {
+    try { sessionStorage.setItem(CACHE_KEY, JSON.stringify({ repo, url, fetchedAt: Date.now() })); } catch (e) {}
+  }
+
+  const cached = fromCache();
+  if (cached) { render(cached.repo, cached.url); return; }
+
+  fetch('https://api.github.com/users/' + username + '/events/public')
+    .then((r) => (r.ok ? r.json() : Promise.reject()))
+    .then((events) => {
+      const push = events.find((e) => e.type === 'PushEvent');
+      if (!push) return;
+      const repo = push.repo.name.split('/')[1];
+      const url = 'https://github.com/' + push.repo.name;
+      render(repo, url);
+      toCache(repo, url);
+    })
+    .catch(() => { /* keep the baked-in github.json value */ });
+})();

--- a/src/js/spiral.js
+++ b/src/js/spiral.js
@@ -4,14 +4,16 @@
 // moving anchor point lands under it, and morphs as it goes. There is no
 // parametric spiral camera, no rotation, and no infinite self-similar zoom.
 // Theme, calm-mode, and reading-mode are read live via MutationObserver, so
-// this file needs no wiring from site.js. Audio playback lives in site.js
-// instead (autoplay needs a real click gesture, which the calm-toggle
-// handler already has).
+// this file needs no wiring from site.js for those. Audio *playback* (play/
+// pause/volume) lives in site.js (autoplay needs a real click gesture, which
+// the calm-toggle handler already has) — this file only ever *reads*
+// #calmAudio's currentTime/paused state, to lock the beat/hum to the track.
 (function () {
   const canvas = document.getElementById('sceneSky');
   if (!canvas) return;
   const ctx = canvas.getContext('2d');
   const root = document.documentElement;
+  const audioEl = document.getElementById('calmAudio'); // safe: base.njk defines it well before this script tag, same as #sceneSky
 
   // ── tuning knobs ──
   const SCALE_X = 0.9;            // curve width as a fraction of viewport width
@@ -20,13 +22,19 @@
   const EXT = 0.5;                // how far (normalized units) open ends bleed past the viewport
   const P = 256;                  // resampled point count shared by every keyframe
 
-  const LEG_SECONDS = 14;         // forward travel time (page2 -> spiral), holds excluded
-  const LEG_SECONDS_BACK = 7;     // return leg: fast, flat unwind (before the low-pass lag)
-  const HOLD_BELL_S = 0.6;        // brief near-stop breath at the page-8 bell
-  const HOLD_COIL_S = 2.0;        // longer humming drift-hold at the golden coil
-  const CALM_MULT = 25;           // calm mode scales every duration above by this
+  // Tempo data for the background track: E-flat major, Camelot 5B, 135 BPM.
+  const BPM = 135;
+  const BEAT = 60 / BPM;          // ~0.444s
+  const BAR = BEAT * 4;           // ~1.778s (4/4)
+  const BEAT_SLEW_K = 0.1;        // per-frame correction pulling the free clock toward real audio position
+  const BEAT_PULSE_SCALE_AMP = 0.03; // orb's beat pulse, ~3% (within the 2-4% range)
 
-  const HUM_FREQ_HZ = 0.15;       // the coil's living hum while held, ~0.1-0.2Hz
+  const LEG_SECONDS = 8 * BAR;    // forward travel time (page2 -> spiral), holds excluded — 8 bars, ~14.2s
+  const LEG_SECONDS_BACK = 4 * BAR; // return leg: fast, flat unwind (before the low-pass lag) — 4 bars, ~7.1s
+  const HOLD_BELL_S = 2 * BEAT;   // brief near-stop breath at the page-8 bell — 2 beats, ~0.89s
+  const HOLD_COIL_S = 4 * BEAT;   // longer humming drift-hold at the golden coil — one bar, ~1.78s
+  const CALM_MULT = 25;           // calm mode / reader mode scales every duration above by this
+
   const HUM_SCALE_AMP = 0.015;    // breathing scale, 1.00 <-> 1.015 (sub-2%)
   const HUM_ROT_AMP = (0.5 * Math.PI) / 180; // +/- 0.5 degrees
 
@@ -208,8 +216,16 @@
   let Lsmoothed = 0; // what's actually rendered — lags behind L only during 'back'
   let holdElapsed = 0;
   let legSecondsFwd, legSecondsBack, holdBellS, holdCoilS;
+
+  // Beat clock: continuously accumulated (never hard-switched), gently
+  // slewed toward real audio position when #calmAudio is playing — a
+  // source-switch on every play/pause would snap discontinuously.
+  let freeBeatClock = 0;
+  // Hum phase: accumulated by delta each frame so a mid-hold frequency
+  // change (calm/reading toggling) changes its rate, not its value.
+  let humPhaseAccum = 0;
   function updateTimings() {
-    const mult = calm ? CALM_MULT : 1;
+    const mult = (calm || readingMode()) ? CALM_MULT : 1; // v9: reading mode drifts slowly too, not just calm mode
     legSecondsFwd = LEG_SECONDS * mult;
     legSecondsBack = LEG_SECONDS_BACK * mult;
     holdBellS = HOLD_BELL_S * mult;
@@ -333,12 +349,19 @@
     ctx.restore();
   }
 
-  function drawOrb() {
+  // `pulse` (0..1, default 0) is the beat envelope — a single uniform scale
+  // around the orb's own center carries every fixed radius/offset below
+  // along for free, so the moon-bite crescent never misaligns as it pulses.
+  function drawOrb(pulse) {
     const orbColor = v('--orb') || '#E9A23B';
     const glow = v('--orb-glow') || 'rgba(233,162,59,0.3)';
     const shadow = v('--sky-top') || '#0A130F';
 
     ctx.save();
+    const beatScale = 1 + BEAT_PULSE_SCALE_AMP * (pulse || 0);
+    ctx.translate(cx, cy);
+    ctx.scale(beatScale, beatScale);
+    ctx.translate(-cx, -cy);
     const rg = ctx.createRadialGradient(cx, cy, 0, cx, cy, 30);
     rg.addColorStop(0, glow);
     rg.addColorStop(1, 'rgba(0,0,0,0)');
@@ -385,6 +408,23 @@
     cs = getComputedStyle(root);
     updateThemeMix(ts);
 
+    // Beat clock: always advances by real elapsed time, then — only while
+    // #calmAudio is actually playing — gently corrected toward its real
+    // currentTime. Correcting rather than replacing means a play/pause
+    // toggle never snaps the phase; it just changes how the clock is fed.
+    freeBeatClock += dtSec;
+    if (audioEl && !audioEl.paused) {
+      freeBeatClock += (audioEl.currentTime - freeBeatClock) * BEAT_SLEW_K;
+    }
+    const beatPhase = (freeBeatClock / BEAT) % 1;
+    const beatPulse = 0.5 * (1 + Math.cos(2 * Math.PI * beatPhase)); // peaks on the downbeat
+
+    // Hum frequency locks to the bar (not the raw beat — a full-speed
+    // beat-locked hum reads as a flutter, not a breath); calm/reading mode
+    // drops to every 4th bar, close to the original ~0.15Hz slow breathing.
+    const humFreqHz = (calm || readingMode()) ? 1 / (4 * BAR) : 1 / BAR;
+    humPhaseAccum = (humPhaseAccum + dtSec * humFreqHz * 2 * Math.PI) % (2 * Math.PI);
+
     let hum = null;
     let trailAlpha = 0.30;
     let renderStyle = null;
@@ -407,8 +447,7 @@
         break;
       case 'holdCoil': {
         holdElapsed += dtSec;
-        const humPhase = holdElapsed * HUM_FREQ_HZ * 2 * Math.PI;
-        hum = { scale: 1 + HUM_SCALE_AMP * Math.sin(humPhase), rot: HUM_ROT_AMP * Math.cos(humPhase) };
+        hum = { scale: 1 + HUM_SCALE_AMP * Math.sin(humPhaseAccum), rot: HUM_ROT_AMP * Math.cos(humPhaseAccum) };
         if (holdElapsed >= holdCoilS) phase = 'back';
         Lsmoothed = L;
         break;
@@ -438,7 +477,7 @@
     paintSky(trailAlpha);
     const pts = pointsAtL(Lsmoothed);
     strokeMorph(pts, anchorPoint(pts, anchorParam(Lsmoothed)), hum, renderStyle);
-    drawOrb();
+    drawOrb(beatPulse);
 
     rafId = requestAnimationFrame(frame);
   }
@@ -457,7 +496,7 @@
   }
 
   function start() {
-    if (rafId || frozen || hidden || readingMode()) return;
+    if (rafId || frozen || hidden) return;
     lastTs = null; // don't count paused/hidden time as elapsed motion
     rafId = requestAnimationFrame(frame);
   }
@@ -484,10 +523,10 @@
     }
   }).observe(root, { attributes: true, attributeFilter: ['data-theme'] });
 
-  // reader mode hides .scene entirely (CSS) — just pause the loop to save cycles
+  // v9: reader mode no longer pauses the loop — it only slows it (via
+  // updateTimings, above) while CSS blurs/washes the scene into an amber glow.
   new MutationObserver(() => {
-    if (readingMode()) stop();
-    else if (!frozen) start();
+    updateTimings();
   }).observe(root, { attributes: true, attributeFilter: ['class'] });
 
   new MutationObserver(() => {


### PR DESCRIPTION
- Reader mode no longer hides the scene (overrides v2/v5): .scene-sky gets a heavy blur + dimmed opacity and .scene gains an amber radial-wash overlay, so reading sits over a soft, slowly-drifting warm glow instead of a blank background. The rAF loop now keeps running in reader mode (only slowed, via the same calm-mode multiplier) rather than pausing — pausing made sense when the scene was hidden, but not once it's the point. Reduced-motion still freezes it for free, since the CSS applies to whatever the canvas currently holds.
- About page: the tile is centered (~640px, margin-inline:auto) instead of left-aligned like every other page, and its glass is scoped ~20% lighter (rgba(12,7,4,0.80)) than the rest of the site's glass panels, without touching the already-tuned ink/clay palette.
- Animation now locks to the background track's tempo (135 BPM, E-flat major / Camelot 5B): the orb gets a subtle beat-synced pulse and the coil-hold's hum locks to bar-aligned frequencies, phase-derived from #calmAudio's real currentTime when it's playing (free-running at the same BPM otherwise). Sent this design through a validation pass first, which caught and fixed three real issues before they shipped: (1) hard- switching between the free clock and audio.currentTime would snap visibly on every play/pause — fixed with a continuously-accumulating clock that's gently slewed toward audio position instead of replaced; (2) locking the hum literally to the raw beat (~2.25Hz) reads as a flutter, not the calm breath intended — moved to bar-locked frequencies (~0.56Hz / ~0.14Hz calm, the latter nearly identical to the original v5 tuning); (3) scaling the orb's disc/glow/moon-bite radii by hand for the pulse risked misaligning the crescent — switched to a single uniform transform around the orb's center, mirroring the existing `hum` pattern in strokeMorph. Hold/leg durations are also now beat/bar- quantized (2 beats, 1 bar, 4 bars, 8 bars) so their lengths land musically, though — noted explicitly rather than overclaimed — the phase machine's transition instants aren't barrier-gated to the live beat grid, only the continuous pulse/hum are truly phase-locked.
- "Currently building" now updates live: github.json's build-time value stays the initial paint and no-JS fallback, and a small client-side script fetches the latest public GitHub event on load, updates the status without a rebuild, and caches the result in sessionStorage for 3 minutes to stay well under the unauthenticated rate limit.

Verified with headless Chromium: reader mode's .scene-sky computed style matches the new blur/opacity exactly and the phase machine keeps advancing while in reader mode (confirmed via sessionStorage state deltas); reduced-motion + reader mode together stay byte-identical over time; the about tile's computed max-width/centering and resolved background color match the plan exactly; with a real (temporarily swapped-in) audio file, the orb's pulse visibly varies both free-running and audio-locked, and a fine-grained pixel-delta comparison across a live mute/unmute toggle shows no discontinuity spike beyond ordinary frame-to-frame variation — the slew fix confirmed working; the live status feature was verified for a successful update, session-cache reuse (zero extra fetches), fetch-failure fallback, and the no-JS path, all against the baked-in github.json value. Full regression + console-error sweep across every page in both themes: clean.