### PR TITLE
Addendum v12: mild slowdown, immersive reader mode, dancing Chitra st…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,8 @@ on:
   # Rebuild every 6 hours so the "currently building" stays fresh
   schedule:
     - cron: "0 */6 * * *"
+    # Refresh Chitra's weather color each Boston morning (~6-7am ET, DST-dependent)
+    - cron: "0 11 * * *"
   # Allow manual triggers from the Actions tab
   workflow_dispatch:
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "Personal site built with Eleventy",
   "scripts": {
     "start": "eleventy --serve",
-    "build": "node scripts/fetch-github.js && eleventy",
-    "fetch": "node scripts/fetch-github.js"
+    "build": "node scripts/fetch-github.js && node scripts/fetch-weather.js && eleventy",
+    "fetch": "node scripts/fetch-github.js",
+    "fetch:weather": "node scripts/fetch-weather.js"
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",

--- a/scripts/fetch-weather.js
+++ b/scripts/fetch-weather.js
@@ -1,0 +1,83 @@
+/**
+ * Fetches Boston's current weather from Open-Meteo (no API key needed) and
+ * writes src/_data/weather.json, so base.njk can bake a --chitra-color CSS
+ * variable — the reading-mode star (and her dancing strands) take their
+ * color from today's real weather.
+ *
+ * Runs at build time (npm run build and in the GitHub Action, once each
+ * morning). If the fetch fails, falls back gracefully to a default color —
+ * the site still builds.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const OUTPUT = path.join(__dirname, "..", "src", "_data", "weather.json");
+const LAT = 42.3601;
+const LON = -71.0589; // Boston — fixed, not configurable
+const URL = `https://api.open-meteo.com/v1/forecast?latitude=${LAT}&longitude=${LON}&current_weather=true&timezone=America%2FNew_York`;
+
+// WMO weathercode buckets -> a night-sky-friendly "mood color", tuned to
+// read well as both a small glowing star and thin curve strokes against the
+// site's light/dark/about palettes.
+const BUCKETS = [
+  { codes: [0], label: "clear", colorHex: "#F5D77A", colorRgb: "245,215,122" },
+  { codes: [1, 2, 3], label: "cloudy", colorHex: "#A9C4D9", colorRgb: "169,196,217" },
+  { codes: [45, 48], label: "fog", colorHex: "#B8B8C8", colorRgb: "184,184,200" },
+  { codes: [51, 53, 55, 56, 57], label: "drizzle", colorHex: "#7FA8A3", colorRgb: "127,168,163" },
+  { codes: [61, 63, 65, 66, 67, 80, 81, 82], label: "rain", colorHex: "#5B84B1", colorRgb: "91,132,177" },
+  { codes: [71, 73, 75, 77, 85, 86], label: "snow", colorHex: "#D6ECEF", colorRgb: "214,236,239" },
+  { codes: [95, 96, 99], label: "storm", colorHex: "#8B6FB3", colorRgb: "139,111,179" },
+];
+const FALLBACK = { label: "clear", colorHex: "#F5D77A", colorRgb: "245,215,122" };
+const bucketFor = (code) => BUCKETS.find((b) => b.codes.includes(code)) || FALLBACK;
+
+async function main() {
+  try {
+    const res = await fetch(URL, { headers: { "User-Agent": "personal-site-build" } });
+    if (!res.ok) throw new Error(`Open-Meteo returned ${res.status}`);
+
+    const data = await res.json();
+    const cw = data.current_weather;
+    if (!cw || typeof cw.weathercode !== "number") throw new Error("unexpected response shape");
+
+    const bucket = bucketFor(cw.weathercode);
+    const tempF = Math.round((cw.temperature * 9) / 5 + 32); // Open-Meteo returns Celsius by default
+
+    fs.writeFileSync(
+      OUTPUT,
+      JSON.stringify(
+        {
+          available: true,
+          weathercode: cw.weathercode,
+          tempF,
+          label: bucket.label,
+          color: bucket.colorHex,
+          colorRgb: bucket.colorRgb,
+          fetchedAt: new Date().toISOString(),
+        },
+        null,
+        2
+      )
+    );
+    console.log(`[fetch-weather] ok: ${bucket.label}, ${tempF}F (code ${cw.weathercode})`);
+  } catch (e) {
+    console.warn("[fetch-weather] error:", e.message);
+    fs.writeFileSync(
+      OUTPUT,
+      JSON.stringify(
+        {
+          available: false,
+          label: FALLBACK.label,
+          color: FALLBACK.colorHex,
+          colorRgb: FALLBACK.colorRgb,
+          fetchedAt: new Date().toISOString(),
+        },
+        null,
+        2
+      )
+    );
+  }
+}
+
+main();

--- a/src/_data/github.json
+++ b/src/_data/github.json
@@ -5,5 +5,5 @@
   "repoUrl": "https://github.com/burpcat/burpcat.github.io",
   "description": "aegon built this",
   "commitMessage": "",
-  "lastPush": "2026-07-11T01:01:48Z"
+  "lastPush": "2026-07-15T20:06:07Z"
 }

--- a/src/_data/weather.json
+++ b/src/_data/weather.json
@@ -1,0 +1,9 @@
+{
+  "available": true,
+  "weathercode": 2,
+  "tempF": 83,
+  "label": "cloudy",
+  "color": "#A9C4D9",
+  "colorRgb": "169,196,217",
+  "fetchedAt": "2026-07-15T22:49:59.914Z"
+}

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.language }}" data-theme="light"{% if page.url == "/about/" %} data-page="about"{% endif %}>
+<html lang="{{ site.language }}" data-theme="light" data-post-count="{{ collections.posts.length }}"{% if page.url == "/about/" %} data-page="about"{% endif %}>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -17,6 +17,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,500;0,600;1,400;1,500&display=swap" rel="stylesheet">
   <link href="https://api.fontshare.com/v2/css?f[]=clash-display@500,600,700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/style.css">
+  {# Chitra's weather color, baked in at build time (see scripts/fetch-weather.js) #}
+  <style>
+    :root {
+      --chitra-color: {{ weather.color or '#F5D77A' }};
+      --chitra-color-rgb: {{ weather.colorRgb or '245,215,122' }};
+    }
+  </style>
 
   {# Anti-flash script — applies theme before paint #}
   <script>

--- a/src/_includes/post.njk
+++ b/src/_includes/post.njk
@@ -10,7 +10,10 @@ layout: base.njk
         <time class="post-date" datetime="{{ page.date | isoDate }}">{{ page.date | dotDate }}</time>
         <span class="reading-time">{{ content | readingTime }}</span>
       </div>
-      <button class="reader-toggle" id="readerToggle" type="button">reader view</button>
+      <button class="reader-toggle glass-surface" id="readerToggle" type="button">
+        <span aria-hidden="true">❧</span>
+        <span class="reader-label">reader view</span>
+      </button>
     </div>
     <h1 class="post-full-title">{{ title }}</h1>
   </header>

--- a/src/about.njk
+++ b/src/about.njk
@@ -15,7 +15,7 @@ permalink: /about/
     </p>
 
     <p style="margin-bottom: 1.6em;">
-      Sometimes on a sixty-degree afternoon — sun threading through leaves, smoke in my lungs, the ground holding my weight — the universe feels like a single continuous thing. <em>Birth and exhale and shadow, all running on the same rule.</em> I try to build software with that feeling somewhere in the room. Tyagaraja's work moves me, so does jamaica pond, beantown.
+      Sometimes on a sixty-degree afternoon — sun threading through leaves, smoke in my lungs, the ground holding my weight — the universe feels like a single continuous thing. <em>Birth and exhale and shadow, all running on the same rule.</em> I try to build software with that feeling somewhere in the room. Tyagaraja's work moves me, so does jamaica pond, beantown. <em>(there's a star pinned dead-center of this site, chitra — everything here quietly dances around her. she changes color with the weather in boston, and in reader mode she's not alone anymore.)</em>
     </p>
 
     <p style="margin-bottom: 1.6em;">

--- a/src/blog/index.njk
+++ b/src/blog/index.njk
@@ -8,7 +8,10 @@ permalink: /blog/
 <section style="max-width: 65ch;">
   <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; margin-bottom: 22px;">
     <p class="section-label" style="margin-bottom: 0;">— ALL WRITING</p>
-    <button class="reader-toggle" id="readerToggle" type="button">reader view</button>
+    <button class="reader-toggle glass-surface" id="readerToggle" type="button">
+      <span aria-hidden="true">❧</span>
+      <span class="reader-label">reader view</span>
+    </button>
   </div>
 
   {% if collections.posts.length %}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -29,6 +29,13 @@
   --spiral-line:  47,110,87;
   --spiral-alpha: 0.42;
 
+  /* Chitra — the reading-mode star's color. Overridden inline in base.njk
+     from src/_data/weather.json (see scripts/fetch-weather.js); these are
+     just the static fallback (a clear-sky gold) for local dev before any
+     fetch has run. */
+  --chitra-color:     #F5D77A;
+  --chitra-color-rgb: 245,215,122;
+
   --glass-tint:   rgba(231,211,184,0.52);
   --glass-solid:  rgba(231,211,184,0.94);
   --glass-edge:   rgba(42,32,24,0.20);
@@ -358,21 +365,27 @@ body.calm-mode .construction { display: none !important; }
 .mute-toggle:hover, .mute-toggle:focus { border-color: var(--text); outline: none; }
 .mute-toggle[aria-pressed="true"] { color: var(--muted); }
 
-/* ── reader view (blog + post pages only) ── */
+/* ── reader view (blog + post pages only) ──
+   .glass-surface (in the markup) supplies the resting-state background/
+   border/backdrop-filter/grain, so this button reads clearly against the
+   moving canvas instead of floating transparently on top of it. */
 .reader-toggle {
-  background: transparent;
-  border: 1px solid var(--border);
   padding: 7px 12px;
   font-family: 'Courier New', Courier, monospace;
   font-size: 11px;
   letter-spacing: 0.05em;
   color: var(--body);
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   min-height: var(--tap-min);
   transition: all 0.15s;
 }
 .reader-toggle:hover, .reader-toggle:focus { border-color: var(--text); outline: none; }
-html.reading-mode .reader-toggle { background: var(--text); color: var(--bg); border-color: var(--text); }
+/* .reader-toggle.glass-surface (not just .reader-toggle) so this beats the
+   later, equal-specificity html.reading-mode .glass-surface reset below */
+html.reading-mode .reader-toggle.glass-surface { background: var(--text); color: var(--bg); border-color: var(--text); }
 
 /* ── construction sticker ── */
 .construction {
@@ -529,15 +542,15 @@ nav a:hover, nav a:focus { color: var(--accent); outline: none; }
 /* v9: the scene stays visible but drifts into a soft, blurred amber wash —
    light through thick frosted glass — instead of disappearing outright. */
 html.reading-mode .scene-sky {
-  filter: blur(48px) saturate(1.1);
-  opacity: 0.55;
+  filter: blur(16px) saturate(1.2);
+  opacity: 0.85;
   transition: filter 0.8s ease, opacity 0.8s ease;
 }
 html.reading-mode .scene::after {
   content: "";
   position: absolute; inset: 0; z-index: 2;
-  background: radial-gradient(60% 50% at 50% 45%, rgba(232,160,70,0.22), transparent 80%),
-              rgba(232,160,70,0.06);
+  background: radial-gradient(60% 50% at 50% 45%, rgba(var(--chitra-color-rgb), 0.16), transparent 80%),
+              rgba(var(--chitra-color-rgb), 0.05);
   mix-blend-mode: soft-light;
   pointer-events: none;
 }
@@ -549,9 +562,11 @@ html.reading-mode .glass-surface {
   -webkit-backdrop-filter: none;
 }
 html.reading-mode .glass-surface::after { display: none; }
-/* the listing/post sections set their own max-width inline — beat it here */
-html.reading-mode section { max-width: 68ch !important; margin-left: auto; margin-right: auto; }
-html.reading-mode .post-full { max-width: 68ch; }
+/* the listing/post sections set their own max-width inline — beat it here.
+   clamp() (not a plain ch cap) lets the column grow fuller on wide monitors
+   and shrink gracefully on narrow ones, instead of a single fixed width. */
+html.reading-mode section { max-width: clamp(46ch, 86vw, 84ch) !important; margin-left: auto; margin-right: auto; }
+html.reading-mode .post-full { max-width: clamp(46ch, 86vw, 84ch); }
 html.reading-mode .post-body {
   line-height: 1.9;
   padding: 34px 36px;
@@ -980,6 +995,7 @@ footer a:hover, footer a:focus { text-decoration: underline; outline: none; }
   .auth-buttons { width: 100%; padding: 8px 0; }
   .auth-buttons .btn { flex: 1; }
   .rss-link { margin-left: 0; }
+  html.reading-mode .post-body { padding: 26px 24px; }
 }
 @media (max-width: 560px) {
   .wrap { padding: 18px 18px 40px; }
@@ -993,4 +1009,7 @@ footer a:hover, footer a:focus { text-decoration: underline; outline: none; }
   .post-title { font-size: 22px; }
   .exp-role { font-size: 20px; }
   .post-excerpt, .exp-desc { font-size: 16px; line-height: 1.75; }
+  html.reading-mode .post-body { padding: 20px 16px; line-height: 1.8; }
+  html.reading-mode section,
+  html.reading-mode .post-full { max-width: clamp(38ch, 94vw, 84ch) !important; }
 }

--- a/src/js/site.js
+++ b/src/js/site.js
@@ -165,9 +165,10 @@ function bindReaderToggle() {
   if (!toggle) return;
   const root = document.documentElement;
   const STORAGE_KEY = 'reading-mode';
+  const labelEl = toggle.querySelector('.reader-label');
 
   const label = () => {
-    toggle.textContent = root.classList.contains('reading-mode') ? 'exit reader view' : 'reader view';
+    labelEl.textContent = root.classList.contains('reading-mode') ? 'exit reader view' : 'reader view';
   };
   label(); // the anti-flash script in <head> already applied the saved state
 

--- a/src/js/spiral.js
+++ b/src/js/spiral.js
@@ -14,6 +14,9 @@
   const ctx = canvas.getContext('2d');
   const root = document.documentElement;
   const audioEl = document.getElementById('calmAudio'); // safe: base.njk defines it well before this script tag, same as #sceneSky
+  // baked in at build time from collections.posts.length — one dancing
+  // strand per blog post, reading-mode only (see drawStrands below).
+  const POST_COUNT = Math.max(1, parseInt(root.getAttribute('data-post-count'), 10) || 1);
 
   // ── tuning knobs ──
   const SCALE_X = 0.9;            // curve width as a fraction of viewport width
@@ -29,16 +32,25 @@
   const BEAT_SLEW_K = 0.1;        // per-frame correction pulling the free clock toward real audio position
   const BEAT_PULSE_SCALE_AMP = 0.03; // orb's beat pulse, ~3% (within the 2-4% range)
 
-  const LEG_SECONDS = 8 * BAR;    // forward travel time (page2 -> spiral), holds excluded — 8 bars, ~14.2s
-  const LEG_SECONDS_BACK = 4 * BAR; // return leg: fast, flat unwind (before the low-pass lag) — 4 bars, ~7.1s
-  const HOLD_BELL_S = 2 * BEAT;   // brief near-stop breath at the page-8 bell — 2 beats, ~0.89s
-  const HOLD_COIL_S = 4 * BEAT;   // longer humming drift-hold at the golden coil — one bar, ~1.78s
+  const LEG_SECONDS = 10 * BAR;    // forward travel time (page2 -> spiral), holds excluded — 10 bars, ~17.8s
+  const LEG_SECONDS_BACK = 5 * BAR; // return leg: fast, flat unwind (before the low-pass lag) — 5 bars, ~8.9s
+  const HOLD_BELL_S = 2.5 * BEAT;   // brief near-stop breath at the page-8 bell — 2.5 beats, ~1.11s
+  const HOLD_COIL_S = 5 * BEAT;    // longer humming drift-hold at the golden coil — 5 beats, ~2.22s
   const CALM_MULT = 25;           // calm mode / reader mode scales every duration above by this
 
-  const HUM_SCALE_AMP = 0.015;    // breathing scale, 1.00 <-> 1.015 (sub-2%)
-  const HUM_ROT_AMP = (0.5 * Math.PI) / 180; // +/- 0.5 degrees
+  const HUM_SCALE_AMP = 0.012;    // breathing scale, 1.00 <-> 1.012 (mild — softened from the original 1.5%)
+  const HUM_ROT_AMP = (0.4 * Math.PI) / 180; // +/- 0.4 degrees (mild — softened from the original 0.5deg)
 
   const LOWPASS_K = 0.06;         // return-leg lag: smaller = laggier/floatier
+
+  // Reading-mode-only: one strand per blog post, dancing in harmony around
+  // the star (Chitra). IDLE_HUM_* gives strands outside the coil-hold a
+  // faint life of their own instead of sitting dead still; the hue spread
+  // is a subtle fan around Chitra's live weather color, not a rainbow.
+  const IDLE_HUM_SCALE_AMP = 0.006;
+  const IDLE_HUM_ROT_AMP = (0.3 * Math.PI) / 180;
+  const STRAND_HUE_SPREAD_DEG = 40; // +/- 20 degrees across the outermost strands
+  const MAX_STRANDS = 12; // safety cap on draw calls as the blog grows
 
   // ── traced keyframes — the owner's sketch, pages 2 through 8 ──
   // Each is a y=f(x) profile: 40 samples, x = i/39 across the width,
@@ -304,14 +316,58 @@
     ctx.globalAlpha = 1;
   }
 
+  // Chitra: the reading-mode star's live weather color (see fetch-weather.js
+  // + base.njk), a bare "r,g,b" triplet like --spiral-line already is.
+  function chitraRgb() {
+    const raw = v('--chitra-color-rgb') || '245,215,122';
+    return raw.split(',').map(Number);
+  }
+
+  // Standard 0-255 rgb <-> {h:0-360, s:0-1, l:0-1} conversions, used only to
+  // fan reading-mode strands out into subtle hue variants of Chitra's color.
+  function rgbToHsl(r, g, b) {
+    r /= 255; g /= 255; b /= 255;
+    const max = Math.max(r, g, b), min = Math.min(r, g, b);
+    const l = (max + min) / 2;
+    if (max === min) return [0, 0, l];
+    const d = max - min;
+    const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    let h;
+    if (max === r) h = (g - b) / d + (g < b ? 6 : 0);
+    else if (max === g) h = (b - r) / d + 2;
+    else h = (r - g) / d + 4;
+    return [h * 60, s, l];
+  }
+  function hslToRgb(h, s, l) {
+    if (s === 0) { const gray = Math.round(l * 255); return [gray, gray, gray]; }
+    const hue2rgb = (p, q, t) => {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1 / 6) return p + (q - p) * 6 * t;
+      if (t < 1 / 2) return q;
+      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+      return p;
+    };
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    const hn = h / 360;
+    return [
+      Math.round(hue2rgb(p, q, hn + 1 / 3) * 255),
+      Math.round(hue2rgb(p, q, hn) * 255),
+      Math.round(hue2rgb(p, q, hn - 1 / 3) * 255),
+    ];
+  }
+
   // Translate the curve so `anchor` lands exactly under the orb, then
   // stroke it as a smoothed path (quadratic curves through consecutive
   // midpoints — cheap, never overshoots, kills the faceted-chord look).
   // `hum` wraps a small breathing scale + rotation around the orb, used
   // only while the coil is held. `style` carries the return leg's dreamy
-  // trail/opacity ramp (absent = forward defaults).
-  function strokeMorph(points, anchor, hum, style) {
-    const rgb = v('--spiral-line') || '62,107,84';
+  // trail/opacity ramp (absent = forward defaults). `rgbOverride` lets
+  // reading-mode's multiple strands (drawStrands, below) each paint in
+  // their own hue-shifted variant of Chitra's color instead of --spiral-line.
+  function strokeMorph(points, anchor, hum, style, rgbOverride) {
+    const rgb = rgbOverride || v('--spiral-line') || '62,107,84';
     const baseAlpha = parseFloat(v('--spiral-alpha')) || 0.42;
     const crispAlpha = baseAlpha * (style ? style.crispMult : 1);
     const underWidth = 11 + (style ? style.underWidthExtra : 0);
@@ -349,12 +405,42 @@
     ctx.restore();
   }
 
+  // Reading-mode only: one strand per blog post (POST_COUNT), all sharing
+  // the same underlying morph geometry — "synchronous" — but each rotated
+  // an even angle around the star and given its own hum phase offset, so
+  // they read as dancing in harmony rather than one line traced N times.
+  // Each strand is also a subtle hue variant of Chitra's live weather color.
+  function drawStrands(points, anchor, hum, style) {
+    const N = Math.min(POST_COUNT, MAX_STRANDS);
+    const [br, bg, bb] = chitraRgb();
+    const [bh, bs, bl] = rgbToHsl(br, bg, bb);
+
+    for (let i = 0; i < N; i++) {
+      const rotation = (2 * Math.PI * i) / N;
+      const strandPhase = humPhaseAccum + (2 * Math.PI * i) / N;
+      const scaleAmp = hum ? HUM_SCALE_AMP : IDLE_HUM_SCALE_AMP;
+      const rotAmp = hum ? HUM_ROT_AMP : IDLE_HUM_ROT_AMP;
+      const strandHum = {
+        scale: 1 + scaleAmp * Math.sin(strandPhase),
+        rot: rotation + rotAmp * Math.cos(strandPhase),
+      };
+      const hueOffset = N > 1 ? -STRAND_HUE_SPREAD_DEG / 2 + (STRAND_HUE_SPREAD_DEG * i) / (N - 1) : 0;
+      const hue = ((bh + hueOffset) % 360 + 360) % 360;
+      const [r, g, b] = hslToRgb(hue, bs, bl);
+      strokeMorph(points, anchor, strandHum, style, `${r},${g},${b}`);
+    }
+  }
+
   // `pulse` (0..1, default 0) is the beat envelope — a single uniform scale
   // around the orb's own center carries every fixed radius/offset below
   // along for free, so the moon-bite crescent never misaligns as it pulses.
+  // In reading mode the orb is presented as Chitra, a named star the
+  // strands dance around — it takes her live weather color instead of the
+  // sun/moon theming.
   function drawOrb(pulse) {
-    const orbColor = v('--orb') || '#E9A23B';
-    const glow = v('--orb-glow') || 'rgba(233,162,59,0.3)';
+    const star = readingMode();
+    const orbColor = star ? (v('--chitra-color') || '#E9A23B') : (v('--orb') || '#E9A23B');
+    const glow = star ? `rgba(${chitraRgb().join(',')},0.34)` : (v('--orb-glow') || 'rgba(233,162,59,0.3)');
     const shadow = v('--sky-top') || '#0A130F';
 
     ctx.save();
@@ -375,8 +461,9 @@
     ctx.fillStyle = orbColor;
     ctx.fill();
 
-    // moon: a soft darker rim bite, faded in/out with the theme crossfade
-    if (themeMix > 0.01) {
+    // moon: a soft darker rim bite, faded in/out with the theme crossfade —
+    // skipped while presented as Chitra, since a fixed star doesn't wax/wane
+    if (themeMix > 0.01 && !star) {
       ctx.globalAlpha = 0.55 * themeMix;
       ctx.beginPath();
       ctx.arc(cx + 2.4, cy - 1.8, 5.5, 0, Math.PI * 2);
@@ -422,7 +509,7 @@
     // Hum frequency locks to the bar (not the raw beat — a full-speed
     // beat-locked hum reads as a flutter, not a breath); calm/reading mode
     // drops to every 4th bar, close to the original ~0.15Hz slow breathing.
-    const humFreqHz = (calm || readingMode()) ? 1 / (4 * BAR) : 1 / BAR;
+    const humFreqHz = (calm || readingMode()) ? 1 / (4 * BAR) : 3 / (4 * BAR);
     humPhaseAccum = (humPhaseAccum + dtSec * humFreqHz * 2 * Math.PI) % (2 * Math.PI);
 
     let hum = null;
@@ -476,7 +563,9 @@
     // crisp; the return leg's low trailAlpha smears into long dream-trails.
     paintSky(trailAlpha);
     const pts = pointsAtL(Lsmoothed);
-    strokeMorph(pts, anchorPoint(pts, anchorParam(Lsmoothed)), hum, renderStyle);
+    const anchor = anchorPoint(pts, anchorParam(Lsmoothed));
+    if (readingMode()) drawStrands(pts, anchor, hum, renderStyle);
+    else strokeMorph(pts, anchor, hum, renderStyle);
     drawOrb(beatPulse);
 
     rafId = requestAnimationFrame(frame);
@@ -487,7 +576,9 @@
     ctx.clearRect(0, 0, W, H);
     paintSky(1);
     const pts = KEYFRAMES[6]; // page 8, the balanced bell — exact keyframe, no interpolation, no hum
-    strokeMorph(pts, anchorPoint(pts, 0.5), null, null);
+    const anchor = anchorPoint(pts, 0.5);
+    if (readingMode()) drawStrands(pts, anchor, null, null);
+    else strokeMorph(pts, anchor, null, null);
     drawOrb();
   }
 
@@ -525,8 +616,13 @@
 
   // v9: reader mode no longer pauses the loop — it only slows it (via
   // updateTimings, above) while CSS blurs/washes the scene into an amber glow.
+  // A quiet easter egg rides along: hovering the scene in reading mode
+  // reveals the star's name via the canvas's native title tooltip (the
+  // .scene wrapper is aria-hidden, so this is a mouse-only nod — the
+  // About page carries the accessible version of this mention).
   new MutationObserver(() => {
     updateTimings();
+    canvas.title = readingMode() ? 'chitra — the star this whole site quietly orbits' : '';
   }).observe(root, { attributes: true, attributeFilter: ['class'] });
 
   new MutationObserver(() => {
@@ -552,6 +648,7 @@
   });
 
   resize();
+  canvas.title = readingMode() ? 'chitra — the star this whole site quietly orbits' : '';
   const restored = loadState();
   if (restored) {
     phase = restored.phase;


### PR DESCRIPTION
…rands

- Soften the spiral's pacing and coil-hold wiggle (longer legs/holds, gentler hum amplitude and frequency) so the animation reads as calmer and more aesthetic rather than twitchy.
- Rework reader mode's background treatment: lighter blur/higher opacity so the scene keeps glowing through the frosted glass like city lights, instead of washing out to a flat blur. Reading column now adapts to viewport width via clamp() instead of a fixed 68ch, with responsive padding at narrow breakpoints.
- Fix the reader-toggle button's visibility: give it a real glass-surface backing panel and a distinct glyph so it no longer disappears against the moving canvas.
- New reading-mode-only feature: one dancing strand per blog post, in synchronized harmony with subtle hue variation, orbiting a named star, Chitra — with a quiet mention on the About page and a hover tooltip.
- Chitra's color now follows Boston's real weather, fetched at build time via Open-Meteo (scripts/fetch-weather.js) and refreshed each morning by a new GitHub Actions cron, following the same pattern as the existing GitHub-status fetch.