### PR TITLE
Addendum v14: calm mode and reader mode become one linked switch

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -37,11 +37,13 @@
   </script>
 
   {% if "/blog/" in page.url %}
-  {# Anti-flash script — applies reader mode before paint (blog + post pages only) #}
+  {# Anti-flash script — applies reader mode before paint (blog + post pages
+     only). Reader mode is derived from calm mode + being in the blog
+     section, so it reads the same 'calm-mode' key calm mode itself uses. #}
   <script>
     (function() {
       try {
-        if (localStorage.getItem('reading-mode') === '1') {
+        if (localStorage.getItem('calm-mode') === '1') {
           document.documentElement.classList.add('reading-mode');
         }
       } catch(e) {}
@@ -86,7 +88,7 @@
         </span>
       </button>
       <button class="calm-toggle" id="calmToggle" aria-pressed="false" aria-label="Toggle calm mode" type="button">
-        <span aria-hidden="true">◐</span>
+        <span class="calm-icon" aria-hidden="true">◐</span>
         <span class="calm-label">calm mode</span>
       </button>
       <button class="mute-toggle" id="muteToggle" type="button" aria-label="Toggle background music">♪</button>
@@ -154,12 +156,18 @@
   <div class="welcome-card glass-surface" role="dialog" aria-modal="true" aria-labelledby="welcome-title">
     <div class="welcome-orb" aria-hidden="true"></div>
     <h2 id="welcome-title" class="welcome-title">Welcome, wanderer.</h2>
-    <p class="welcome-body">You've found a small bright thing in a vast quiet space. Two things before you explore:</p>
+    <p class="welcome-body">You've found a small bright thing in a vast quiet space. A few things before you explore:</p>
     <div class="welcome-theme">
       <span class="welcome-label">this place has a day and a night —</span>
       <div class="welcome-modes">
         <button type="button" data-mode="light" id="wm-light">sun</button>
         <button type="button" data-mode="dark" id="wm-dark">moon</button>
+      </div>
+    </div>
+    <div class="welcome-theme">
+      <span class="welcome-label">prefer stillness? —</span>
+      <div class="welcome-modes">
+        <button type="button" id="wm-calm" aria-pressed="false">calm mode</button>
       </div>
     </div>
     <label class="welcome-music">

--- a/src/_includes/post.njk
+++ b/src/_includes/post.njk
@@ -10,8 +10,8 @@ layout: base.njk
         <time class="post-date" datetime="{{ page.date | isoDate }}">{{ page.date | dotDate }}</time>
         <span class="reading-time">{{ content | readingTime }}</span>
       </div>
-      <button class="reader-toggle glass-surface" id="readerToggle" type="button">
-        <span aria-hidden="true">❧</span>
+      <button class="reader-toggle glass-surface" id="readerToggle" aria-pressed="false" type="button">
+        <span class="calm-icon" aria-hidden="true">❧</span>
         <span class="reader-label">reader view</span>
       </button>
     </div>

--- a/src/blog/index.njk
+++ b/src/blog/index.njk
@@ -8,8 +8,8 @@ permalink: /blog/
 <section style="max-width: 65ch;">
   <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; margin-bottom: 22px;">
     <p class="section-label" style="margin-bottom: 0;">— ALL WRITING</p>
-    <button class="reader-toggle glass-surface" id="readerToggle" type="button">
-      <span aria-hidden="true">❧</span>
+    <button class="reader-toggle glass-surface" id="readerToggle" aria-pressed="false" type="button">
+      <span class="calm-icon" aria-hidden="true">❧</span>
       <span class="reader-label">reader view</span>
     </button>
   </div>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -19,6 +19,15 @@
   --geo-yellow:   #D08A2E;
   --geo-pink:     #A85440;
 
+  /* calm mode icon — "on" tuned for contrast against the toggle's filled
+     pressed state (var(--text)); "off" matches this theme's --muted value
+     (already proven legible at rest), copied literally rather than
+     `var(--muted)` so the icon keeps one consistent identity everywhere,
+     including pages (About) that locally override --muted for their own
+     palette. */
+  --calm-on:      #6FE3B4;
+  --calm-off:     #6E5C48;
+
   --sky-top:      #F0D9B4;
   --sky-bottom:   #E0B181;
   --ridge-far:    #9C8460;
@@ -62,6 +71,10 @@
   --rss:          #E0975A;
   --geo-yellow:   #E9A23B;
   --geo-pink:     #B98090;
+
+  /* calm mode icon — see light theme above for the rationale */
+  --calm-on:      #1D6B4A;
+  --calm-off:     #93A08E;
 
   --sky-top:      #0A130F;
   --sky-bottom:   #1C3A34;
@@ -141,6 +154,18 @@ body {
 body.calm-mode .new-badge,
 body.calm-mode .dot { animation: none !important; }
 body.calm-mode .construction { display: none !important; }
+/* de-frost every glassy panel, site-wide — each page keeps its own colors
+   (light/dark/About), this only removes the blur/translucency. Reading
+   mode (blog + post pages only) is a derived subset of calm mode, so this
+   already covers what reading mode used to flatten on its own. */
+body.calm-mode { background: var(--bg); }
+body.calm-mode .glass-surface {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+body.calm-mode .glass-surface::after { display: none; }
 
 /* ───────────────────────────────────────
    BACKGROUND SCENE — fixed sky/spiral/ridge behind everything
@@ -346,6 +371,13 @@ body.calm-mode .construction { display: none !important; }
   border-color: var(--text);
 }
 
+/* calm icon — shared by the header calm-toggle and the blog's reader-toggle
+   (same underlying switch, see site.js); "on" tuned for contrast against
+   each button's own pressed-state fill above. */
+.calm-icon { color: var(--calm-off); transition: color 0.2s; }
+.calm-toggle[aria-pressed="true"] .calm-icon,
+.reader-toggle[aria-pressed="true"] .calm-icon { color: var(--calm-on); }
+
 /* ── mute (calm-mode audio) ── */
 .mute-toggle {
   background: transparent;
@@ -537,7 +569,10 @@ nav a:hover, nav a:focus { color: var(--accent); outline: none; }
 }
 
 /* ───────────────────────────────────────
-   READER MODE — a calm, solid reading surface (blog + post pages only)
+   READER MODE — blog + post pages only. Derived from calm mode (see
+   body.calm-mode above, which already de-frosts glass site-wide) plus
+   being in the blog section — this block only layers on the extra,
+   blog-exclusive "immersive reading" atmosphere on top of that.
    ─────────────────────────────────────── */
 /* v9: the scene stays visible but drifts into a soft, blurred amber wash —
    light through thick frosted glass — instead of disappearing outright. */
@@ -554,14 +589,6 @@ html.reading-mode .scene::after {
   mix-blend-mode: soft-light;
   pointer-events: none;
 }
-html.reading-mode body { background: var(--bg); }
-html.reading-mode .glass-surface {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
-}
-html.reading-mode .glass-surface::after { display: none; }
 /* the listing/post sections set their own max-width inline — beat it here.
    clamp() (not a plain ch cap) lets the column grow fuller on wide monitors
    and shrink gracefully on narrow ones, instead of a single fixed width. */
@@ -887,6 +914,10 @@ footer a:hover, footer a:focus { text-decoration: underline; outline: none; }
   min-height: var(--tap-min);
 }
 .welcome-modes button[aria-pressed="true"] { color: var(--warm-accent); border-color: var(--warm-accent); }
+/* the calm button gets its own color (matching the header/reader-toggle
+   icon) rather than --warm-accent, to read as a distinct concept from the
+   day/night choice above it */
+#wm-calm[aria-pressed="true"] { color: var(--calm-on); border-color: var(--calm-on); }
 .welcome-music {
   display: flex; align-items: flex-start; gap: 10px;
   margin: 16px 0 22px;

--- a/src/js/nav.js
+++ b/src/js/nav.js
@@ -84,6 +84,14 @@
     newMain.setAttribute('tabindex', '-1');
     reviveScripts(newMain);
 
+    // reading-mode is derived (calm mode + being in the blog section) and
+    // must be recomputed for the destination page — location.pathname isn't
+    // updated yet here (pushState happens after applySwap returns), so use
+    // the url this navigation is going to, not the current location.
+    const isBlog = new URL(url, location.href).pathname.indexOf('/blog/') !== -1;
+    document.documentElement.classList.toggle('reading-mode',
+      document.body.classList.contains('calm-mode') && isBlog);
+
     if (window.__site && window.__site.bindReaderToggle) window.__site.bindReaderToggle();
 
     const hash = url.includes('#') ? url.slice(url.indexOf('#') + 1) : '';

--- a/src/js/site.js
+++ b/src/js/site.js
@@ -55,10 +55,16 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal()
   });
 })();
 
-// ── calm mode (animation tempo only) ──
+// ── calm mode (site-wide: tempo + de-frosted glass; reading-mode is
+// derived from this, see below) ──
 // v8 supersedes the v1 coupling: calm mode used to force-start/stop the
 // background track. Music is now its own independent thing — see the
-// music module below — calm mode here only ever touches tempo (v4/v5).
+// music module below — calm mode here only ever touches tempo/visuals (v4/v5).
+// v14: calm mode and reader mode (blog + post pages only) are now one
+// shared switch. Reader mode is just "calm mode, while in the blog
+// section" — html.reading-mode is toggled here alongside body.calm-mode,
+// recomputed on every change since soft-navigation can move the user in
+// or out of the blog section without a full page load.
 (function () {
   const toggle = document.getElementById('calmToggle');
   if (!toggle) return;
@@ -71,6 +77,8 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal()
     toggle.setAttribute('aria-pressed', String(on));
     if (label) label.textContent = on ? 'calm: on' : 'calm mode';
     try { localStorage.setItem(STORAGE_KEY, on ? '1' : '0'); } catch (e) {}
+    const isBlogSection = location.pathname.indexOf('/blog/') !== -1;
+    document.documentElement.classList.toggle('reading-mode', on && isBlogSection);
   };
 
   let initial = false;
@@ -81,6 +89,9 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal()
   toggle.addEventListener('click', () => {
     apply(!document.body.classList.contains('calm-mode'));
   });
+
+  window.__site = window.__site || {};
+  window.__site.setCalmMode = apply; // bridge for the reader-toggle button and the welcome popup
 })();
 
 // ── background music (independent of calm mode; persists across pages) ──
@@ -156,28 +167,43 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal()
 })();
 
 // ── reader mode (blog + post pages only) ──
+// Reader mode is just calm mode's derived state while in the blog section
+// (see the calm-mode module above) — this button is a second switch on the
+// same shared state, not its own flag. Because the header calm-toggle is
+// simultaneously visible and clickable on every blog page, this can't just
+// sync itself on its own click the way the welcome popup's day/night
+// buttons do (those are never on-screen at the same time as the header
+// switch) — it has to react live to changes made from *either* control, so
+// it observes html's class list instead.
 // Re-invokable (see window.__site.bindReaderToggle below) because soft
 // navigation (nav.js) can swap in a fresh #readerToggle node on a page that
 // didn't have one at initial load — each swap discards any previous button
-// (and its listener) entirely, so there's no double-binding risk.
+// (and its listener) entirely, so there's no double-binding risk. The old
+// observer is disconnected first so repeated re-binds don't accumulate.
+let readerModeObserver = null;
 function bindReaderToggle() {
+  if (readerModeObserver) { readerModeObserver.disconnect(); readerModeObserver = null; }
+
   const toggle = document.getElementById('readerToggle');
   if (!toggle) return;
   const root = document.documentElement;
-  const STORAGE_KEY = 'reading-mode';
   const labelEl = toggle.querySelector('.reader-label');
 
-  const label = () => {
-    labelEl.textContent = root.classList.contains('reading-mode') ? 'exit reader view' : 'reader view';
+  const sync = () => {
+    const on = root.classList.contains('reading-mode');
+    toggle.setAttribute('aria-pressed', String(on));
+    labelEl.textContent = on ? 'exit reader view' : 'reader view';
   };
-  label(); // the anti-flash script in <head> already applied the saved state
+  sync(); // the anti-flash script in <head> already applied the saved state
 
   toggle.addEventListener('click', () => {
-    const on = !root.classList.contains('reading-mode');
-    root.classList.toggle('reading-mode', on);
-    try { localStorage.setItem(STORAGE_KEY, on ? '1' : '0'); } catch (e) {}
-    label();
+    if (window.__site && window.__site.setCalmMode) {
+      window.__site.setCalmMode(!document.body.classList.contains('calm-mode'));
+    }
   });
+
+  readerModeObserver = new MutationObserver(sync);
+  readerModeObserver.observe(root, { attributes: true, attributeFilter: ['class'] });
 }
 bindReaderToggle();
 
@@ -197,6 +223,7 @@ window.__site.bindReaderToggle = bindReaderToggle;
   const root = document.documentElement;
   const lightBtn = document.getElementById('wm-light');
   const darkBtn = document.getElementById('wm-dark');
+  const calmBtn = document.getElementById('wm-calm');
   const musicCheck = document.getElementById('welcome-music-check');
   const enterBtn = document.getElementById('welcome-enter');
 
@@ -207,6 +234,11 @@ window.__site.bindReaderToggle = bindReaderToggle;
   }
   syncModeButtons();
 
+  function syncCalmButton() {
+    if (calmBtn) calmBtn.setAttribute('aria-pressed', String(document.body.classList.contains('calm-mode')));
+  }
+  syncCalmButton();
+
   if (lightBtn) lightBtn.addEventListener('click', () => {
     if (window.__site && window.__site.setTheme) window.__site.setTheme('light');
     syncModeButtons();
@@ -215,9 +247,13 @@ window.__site.bindReaderToggle = bindReaderToggle;
     if (window.__site && window.__site.setTheme) window.__site.setTheme('dark');
     syncModeButtons();
   });
+  if (calmBtn) calmBtn.addEventListener('click', () => {
+    if (window.__site && window.__site.setCalmMode) window.__site.setCalmMode(!document.body.classList.contains('calm-mode'));
+    syncCalmButton();
+  });
 
   function getFocusable() {
-    return [lightBtn, darkBtn, musicCheck, enterBtn].filter(Boolean);
+    return [lightBtn, darkBtn, calmBtn, musicCheck, enterBtn].filter(Boolean);
   }
 
   function trapKeydown(e) {

--- a/src/js/spiral.js
+++ b/src/js/spiral.js
@@ -244,10 +244,12 @@
   const MUSIC_GATE_SLEW_K = 0.04;
   let musicGate = 0;
   function updateTimings() {
-    // calm mode is an explicit "make everything as slow as possible" toggle,
-    // so it wins if both are active; reading mode alone gets its own gentler
-    // (but still slow) pace — dreamy and visibly moving, not near-frozen.
-    const mult = calm ? CALM_MULT : (readingMode() ? READING_MULT : 1);
+    // reading mode is now derived from calm mode (calm + blog section), so
+    // it's always a subset of calm — it wins first here to keep its own
+    // tuned, gentler pace (dreamy and visibly moving, not near-frozen)
+    // reachable; calm mode outside the blog section still gets the harsher
+    // near-freeze on its own.
+    const mult = readingMode() ? READING_MULT : (calm ? CALM_MULT : 1);
     legSecondsFwd = LEG_SECONDS * mult;
     legSecondsBack = LEG_SECONDS_BACK * mult;
     holdBellS = HOLD_BELL_S * mult;


### PR DESCRIPTION
Reader mode (blog + post pages) is now derived from calm mode plus being in the blog section, rather than its own independent flag — the header calm-toggle and the blog's reader-toggle drive the same shared state and stay in sync no matter which one is clicked, mirroring the existing theme-switch/welcome-popup bridge pattern. Calm mode's de-frosted-glass effect becomes site-wide (previously reader-mode-only), the welcome popup gains its own calm-mode button, and the calm icon gets four theme-related colors (on/off x light/dark). Also fixes a pre-existing bug where reader mode's blog-only visuals could leak onto other pages after a soft-navigation.